### PR TITLE
feat: implement null parser with validation and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,7 @@ name = "synson"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-pub mod json_parse_error;
-pub mod models;
+pub mod model;
+pub mod parser;
 
-pub use crate::models::{JsonParseError, JsonValue};
+pub use model::{JsonParseError, JsonValue};
+pub use parser::parse_null;

--- a/src/model/json_parse_error.rs
+++ b/src/model/json_parse_error.rs
@@ -1,4 +1,9 @@
-use crate::models::JsonParseError;
+/// Represents an error encountered while parsing JSON.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonParseError {
+    pub message: String,
+    pub position: usize,
+}
 
 impl JsonParseError {
     /// Creates a new JsonParseError.
@@ -15,6 +20,8 @@ impl JsonParseError {
     /// # Examples
     ///
     /// ```
+    /// use synson::model::json_parse_error::JsonParseError;
+    ///
     /// let err = JsonParseError::new("Unexpected token", 12);
     /// assert_eq!(err.message, "Unexpected token");
     /// ```

--- a/src/model/json_value.rs
+++ b/src/model/json_value.rs
@@ -11,9 +11,3 @@ pub enum JsonValue {
     Object(std::collections::HashMap<String, JsonValue>),
 }
 
-/// Represents an error encountered while parsing JSON.
-#[derive(Debug, Clone, PartialEq)]
-pub struct JsonParseError {
-    pub message: String,
-    pub position: usize,
-}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,0 +1,5 @@
+pub mod json_parse_error;
+pub mod json_value;
+
+pub use json_parse_error::JsonParseError;
+pub use json_value::JsonValue;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,2 @@
+pub mod null;
+pub use null::parse_null;

--- a/src/parser/null.rs
+++ b/src/parser/null.rs
@@ -1,0 +1,35 @@
+use crate::JsonValue;
+
+/// Attempts to parse the JSON `null` literal.
+///
+/// # Arguments
+///
+/// * `input` - A string slice that should start with "null".
+///
+/// # Returns
+///
+/// `Some((JsonValue::Null, remaining_input))` if successful, otherwise `None`.
+///
+/// # Examples
+///
+/// ```
+/// use synson::parser::parse_null;
+/// use synson::JsonValue;
+///
+/// assert_eq!(
+///     parse_null("null "),
+///     Some((JsonValue::Null, " "))
+/// );
+/// assert_eq!(parse_null("nul"), None);
+/// ```
+pub fn parse_null(input: &str) -> Option<(JsonValue, &str)> {
+    let input = input.trim_start();
+    if let Some(rest) = input.strip_prefix("null") {
+        match rest.chars().next() {
+            Some(c) if c.is_ascii_alphanumeric() => None,
+            _ => Some((JsonValue::Null, rest)),
+        }
+    } else {
+        None
+    }
+}

--- a/tests/null.rs
+++ b/tests/null.rs
@@ -1,0 +1,14 @@
+use synson::{parse_null, JsonValue};
+
+#[test]
+fn should_parse_null_correctly() {
+    assert_eq!(parse_null("null"), Some((JsonValue::Null, "")));
+    assert_eq!(parse_null("null "), Some((JsonValue::Null, " ")));
+    assert_eq!(parse_null("null\tmore"), Some((JsonValue::Null, "\tmore")));
+}
+
+#[test]
+fn should_fail_on_invalid_null() {
+    assert_eq!(parse_null("nul"), None);
+    assert_eq!(parse_null("nulla"), None);
+}


### PR DESCRIPTION
- Added `parse_null` to recognize the "null" literal from a JSON input.
- Trim-starts input and rejects invalid extensions (e.g. "nulla").
- Added tests for valid and invalid null inputs.