### PR TITLE
feat: implement boolean parser with support for true and false

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod model;
 pub mod parser;
 
 pub use model::{JsonParseError, JsonValue};
+pub use parser::parse_bool;
 pub use parser::parse_null;

--- a/src/model/json_value.rs
+++ b/src/model/json_value.rs
@@ -10,4 +10,3 @@ pub enum JsonValue {
     Array(Vec<JsonValue>),
     Object(std::collections::HashMap<String, JsonValue>),
 }
-

--- a/src/parser/bool.rs
+++ b/src/parser/bool.rs
@@ -1,0 +1,45 @@
+use crate::model::JsonValue;
+
+/// Attempts to parse a JSON boolean literal (`true` or `false`).
+///
+/// # Arguments
+///
+/// * `input` - A string slice to parse.
+///
+/// # Returns
+///
+/// `Some((JsonValue::Bool(value), remaining_input))` if successful, otherwise `None`.
+///
+/// # Examples
+///
+/// ```
+/// use synson::parser::parse_bool;
+/// use synson::JsonValue;
+///
+/// assert_eq!(parse_bool("true "), Some((JsonValue::Bool(true), " ")));
+/// assert_eq!(parse_bool("false"), Some((JsonValue::Bool(false), "")));
+/// assert_eq!(parse_bool("fals"), None);
+/// ```
+pub fn parse_bool(input: &str) -> Option<(JsonValue, &str)> {
+    let input = input.trim_start();
+
+    if let Some(rest) = input.strip_prefix("true") {
+        if let Some(c) = rest.chars().next() {
+            if c.is_ascii_alphanumeric() {
+                return None;
+            }
+        }
+        return Some((JsonValue::Bool(true), rest));
+    }
+
+    if let Some(rest) = input.strip_prefix("false") {
+        if let Some(c) = rest.chars().next() {
+            if c.is_ascii_alphanumeric() {
+                return None;
+            }
+        }
+        return Some((JsonValue::Bool(false), rest));
+    }
+
+    None
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,2 +1,5 @@
+pub mod bool;
 pub mod null;
+
+pub use bool::parse_bool;
 pub use null::parse_null;

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -1,0 +1,18 @@
+use synson::{parse_bool, JsonValue};
+
+#[test]
+fn should_parse_true_and_false() {
+    assert_eq!(parse_bool("true"), Some((JsonValue::Bool(true), "")));
+    assert_eq!(parse_bool("false"), Some((JsonValue::Bool(false), "")));
+    assert_eq!(
+        parse_bool("false more"),
+        Some((JsonValue::Bool(false), " more"))
+    );
+}
+
+#[test]
+fn should_reject_invalid_booleans() {
+    assert_eq!(parse_bool("tru"), None);
+    assert_eq!(parse_bool("truefalse"), None);
+    assert_eq!(parse_bool("falsey"), None);
+}


### PR DESCRIPTION
- Added `parse_bool` function to handle JSON booleans.
- Rejects malformed variants like "tru", "falsey", or "true1".
- Includes unit tests for valid and invalid boolean cases.