### PR TITLE
feat: support full JSON number parsing including scientific notation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,4 @@ pub mod model;
 pub mod parser;
 
 pub use model::{JsonParseError, JsonValue};
-pub use parser::parse_bool;
-pub use parser::parse_null;
+pub use parser::{parse_bool, parse_null, parse_number};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,7 @@
 pub mod bool;
 pub mod null;
+pub mod number;
 
 pub use bool::parse_bool;
 pub use null::parse_null;
+pub use number::parse_number;

--- a/src/parser/number.rs
+++ b/src/parser/number.rs
@@ -1,0 +1,101 @@
+use crate::model::JsonValue;
+
+/// Attempts to parse a JSON number (integers, floats and scientific notation).
+///
+/// # Arguments
+///
+/// * `input` - A string slice to parse.
+///
+/// # Returns
+///
+/// `Some((JsonValue::Number(value), remaining_input))` if successful, otherwise `None`.
+pub fn parse_number(input: &str) -> Option<(JsonValue, &str)> {
+    let input = input.trim_start();
+    let mut chars = input.char_indices().peekable();
+    let mut end_index = 0;
+    let mut has_digits = false;
+
+    // Optional minus sign
+    if let Some((_, '-')) = chars.peek() {
+        chars.next();
+    }
+
+    // Reject if leading with dot
+    if let Some((_, '.')) = chars.peek() {
+        return None;
+    }
+
+    // Integer part
+    while let Some(&(i, c)) = chars.peek() {
+        if c.is_ascii_digit() {
+            has_digits = true;
+            end_index = i + 1;
+            chars.next();
+        } else {
+            break;
+        }
+    }
+
+    // Fractional part
+    if let Some(&(_, '.')) = chars.peek() {
+        chars.next(); // consume '.'
+
+        let mut has_frac_digits = false;
+        while let Some(&(j, c)) = chars.peek() {
+            if c.is_ascii_digit() {
+                has_digits = true;
+                has_frac_digits = true;
+                end_index = j + 1;
+                chars.next();
+            } else {
+                break;
+            }
+        }
+
+        if !has_frac_digits {
+            return None;
+        }
+    }
+
+    if !has_digits {
+        return None;
+    }
+
+    // Exponent part
+    if let Some(&(_, 'e' | 'E')) = chars.peek() {
+        chars.next(); // consume 'e' or 'E'
+
+        // Optional sign
+        if let Some(&(_, '+' | '-')) = chars.peek() {
+            chars.next();
+        }
+
+        let mut has_exp_digits = false;
+        while let Some(&(i, c)) = chars.peek() {
+            if c.is_ascii_digit() {
+                has_exp_digits = true;
+                end_index = i + 1;
+                chars.next();
+            } else {
+                break;
+            }
+        }
+
+        if !has_exp_digits {
+            return None;
+        }
+    }
+
+    let (matched, rest) = input.split_at(end_index);
+
+    if let Some(c) = rest.chars().next() {
+        if c.is_ascii_alphabetic() || c == '.' {
+            return None;
+        }
+    }
+
+    matched
+        .parse::<f64>()
+        .ok()
+        .map(|num| (JsonValue::Number(num), rest))
+}

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -1,0 +1,36 @@
+use synson::{parse_number, JsonValue};
+
+#[test]
+fn should_parse_valid_numbers() {
+    assert_eq!(parse_number("0"), Some((JsonValue::Number(0.0), "")));
+    assert_eq!(parse_number("42 "), Some((JsonValue::Number(42.0), " ")));
+    assert_eq!(
+        parse_number("-12.5,"),
+        Some((JsonValue::Number(-12.5), ","))
+    );
+    assert_eq!(parse_number("1e3"), Some((JsonValue::Number(1000.0), "")));
+    assert_eq!(parse_number("2E2 "), Some((JsonValue::Number(200.0), " ")));
+    assert_eq!(
+        parse_number("-3.5e-1"),
+        Some((JsonValue::Number(-0.35), ""))
+    );
+    assert_eq!(parse_number("0.5e+2"), Some((JsonValue::Number(50.0), "")));
+}
+
+#[test]
+fn should_reject_invalid_numbers() {
+    assert_eq!(parse_number(""), None);
+    assert_eq!(parse_number("-"), None);
+    assert_eq!(parse_number("."), None);
+    assert_eq!(parse_number("12abc"), None);
+    assert_eq!(parse_number("--1"), None);
+    assert_eq!(parse_number("1.2.3"), None);
+    assert_eq!(parse_number("1e"), None);
+    assert_eq!(parse_number("1e+"), None);
+    assert_eq!(parse_number("1e-"), None);
+    assert_eq!(parse_number("1e+2.3"), None);
+    assert_eq!(parse_number("1e-2.3"), None);
+    assert_eq!(parse_number("3.1415rest"), None);
+    assert_eq!(parse_number(".5"), None);
+    assert_eq!(parse_number("5."), None);
+}


### PR DESCRIPTION
- Implemented full `parse_number` function:
  - Handles integers, floats, and scientific notation (e.g. 1e3, -3.5E-2)
  - Validates input against RFC 8259 requirements
  - Rejects malformed cases like ".5", "1.2.3", "1e+", "12abc", etc.
- Added extensive unit tests covering both valid and invalid cases.
- Ensures parser rejects ambiguous or non-conformant number formats.