### PR TITLE
feat: implement string parser with support for basic escape sequences

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ pub mod model;
 pub mod parser;
 
 pub use model::{JsonParseError, JsonValue};
-pub use parser::{parse_bool, parse_null, parse_number};
+pub use parser::{parse_bool, parse_null, parse_number, parse_string};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,9 @@
 pub mod bool;
 pub mod null;
 pub mod number;
+pub mod string;
 
 pub use bool::parse_bool;
 pub use null::parse_null;
 pub use number::parse_number;
+pub use string::parse_string;

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -1,0 +1,61 @@
+use crate::model::JsonValue;
+
+/// Attempts to parse a JSON string literal with basic escapes.
+///
+/// # Arguments
+///
+/// * `input` - A string slice starting with a double quote (`"`).
+///
+/// # Returns
+///
+/// `Some((JsonValue::String(value), remaining_input))` if successful, otherwise `None`.
+///
+/// # Examples
+///
+/// ```
+/// use synson::{parse_string, JsonValue};
+///
+/// assert_eq!(
+///     parse_string("\"hello\""),
+///     Some((JsonValue::String("hello".to_string()), ""))
+/// );
+///
+/// assert_eq!(
+///     parse_string("\"line\\nbreak\""),
+///     Some((JsonValue::String("line\nbreak".to_string()), ""))
+/// );
+/// ```
+pub fn parse_string(input: &str) -> Option<(JsonValue, &str)> {
+    let input = input.trim_start();
+    let mut chars = input.char_indices();
+
+    let (_, first) = chars.next()?;
+    if first != '"' {
+        return None;
+    }
+
+    let mut result = String::new();
+    let mut escape = false;
+
+    for (i, c) in chars {
+        if escape {
+            match c {
+                '"' => result.push('"'),
+                '\\' => result.push('\\'),
+                'n' => result.push('\n'),
+                't' => result.push('\t'),
+                _ => return None,
+            }
+            escape = false;
+        } else if c == '\\' {
+            escape = true;
+        } else if c == '"' {
+            let rest = &input[i + 1..];
+            return Some((JsonValue::String(result), rest));
+        } else {
+            result.push(c);
+        }
+    }
+
+    None
+}

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,0 +1,40 @@
+use synson::{parse_string, JsonValue};
+
+#[test]
+fn should_parse_basic_strings() {
+    assert_eq!(
+        parse_string("\"hello\""),
+        Some((JsonValue::String("hello".to_string()), ""))
+    );
+    assert_eq!(
+        parse_string("\"with space\" "),
+        Some((JsonValue::String("with space".to_string()), " "))
+    );
+}
+
+#[test]
+fn should_parse_escaped_strings() {
+    assert_eq!(
+        parse_string("\"line\\nbreak\""),
+        Some((JsonValue::String("line\nbreak".to_string()), ""))
+    );
+    assert_eq!(
+        parse_string("\"tab\\tseparated\""),
+        Some((JsonValue::String("tab\tseparated".to_string()), ""))
+    );
+    assert_eq!(
+        parse_string("\"quote: \\\"\""),
+        Some((JsonValue::String("quote: \"".to_string()), ""))
+    );
+    assert_eq!(
+        parse_string("\"backslash: \\\\\""),
+        Some((JsonValue::String("backslash: \\".to_string()), ""))
+    );
+}
+
+#[test]
+fn should_reject_invalid_strings() {
+    assert_eq!(parse_string("not a string"), None);
+    assert_eq!(parse_string("\"unclosed"), None);
+    assert_eq!(parse_string("\"bad\\escape\""), None);
+}


### PR DESCRIPTION
- Added `parse_string` to handle JSON strings with escapes (\\, \", \n, \t).
- Rejects malformed or unterminated strings.
- Includes rustdoc with usage examples.
- Added unit tests covering simple, escaped, and invalid strings.