### PR TITLE
feat: implement array parser with strict syntax and support for basic…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ pub mod model;
 pub mod parser;
 
 pub use model::{JsonParseError, JsonValue};
-pub use parser::{parse_bool, parse_null, parse_number, parse_string};
+pub use parser::{parse_array, parse_bool, parse_null, parse_number, parse_string};

--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -1,0 +1,78 @@
+use crate::model::JsonValue;
+use crate::parser::{parse_bool, parse_null, parse_number, parse_string};
+
+/// Attempts to parse a JSON array of simple values (null, bool, number, string).
+///
+/// # Arguments
+///
+/// * `input` - A string slice expected to start with `'['`.
+///
+/// # Returns
+///
+/// `Some((JsonValue::Array(vec), remaining_input))` if successful, otherwise `None`.
+///
+/// # Examples
+///
+/// ```
+/// use synson::{parse_array, JsonValue};
+///
+/// assert_eq!(
+///     parse_array("[1, true, \"ok\"]"),
+///     Some((
+///         JsonValue::Array(vec![
+///             JsonValue::Number(1.0),
+///             JsonValue::Bool(true),
+///             JsonValue::String("ok".to_string())
+///         ]),
+///         ""
+///     ))
+/// );
+///
+/// assert_eq!(
+///     parse_array("[ ]"),
+///     Some((JsonValue::Array(vec![]), ""))
+/// );
+/// ```
+pub fn parse_array(input: &str) -> Option<(JsonValue, &str)> {
+    let mut input = input.trim_start();
+
+    if !input.starts_with('[') {
+        return None;
+    }
+    input = &input[1..];
+
+    let mut values = Vec::new();
+
+    loop {
+        input = input.trim_start();
+
+        if let Some(rest) = input.strip_prefix(']') {
+            return Some((JsonValue::Array(values), rest));
+        }
+
+        let (value, rest) = parse_value(input)?;
+        values.push(value);
+        input = rest.trim_start();
+
+        if let Some(rest) = input.strip_prefix(',') {
+            input = rest;
+
+            if input.trim_start().starts_with(']') {
+                return None;
+            }
+
+            continue;
+        } else if let Some(rest) = input.strip_prefix(']') {
+            return Some((JsonValue::Array(values), rest));
+        } else {
+            return None;
+        }
+    }
+}
+
+fn parse_value(input: &str) -> Option<(JsonValue, &str)> {
+    parse_null(input)
+        .or_else(|| parse_bool(input))
+        .or_else(|| parse_number(input))
+        .or_else(|| parse_string(input))
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,8 +1,10 @@
+pub mod array;
 pub mod bool;
 pub mod null;
 pub mod number;
 pub mod string;
 
+pub use array::parse_array;
 pub use bool::parse_bool;
 pub use null::parse_null;
 pub use number::parse_number;

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1,0 +1,26 @@
+use synson::{parse_array, JsonValue};
+
+#[test]
+fn should_parse_simple_arrays() {
+    assert_eq!(
+        parse_array("[1, true, \"ok\"]"),
+        Some((
+            JsonValue::Array(vec![
+                JsonValue::Number(1.0),
+                JsonValue::Bool(true),
+                JsonValue::String("ok".to_string())
+            ]),
+            ""
+        ))
+    );
+
+    assert_eq!(parse_array(" [ ] "), Some((JsonValue::Array(vec![]), " ")));
+}
+
+#[test]
+fn should_reject_malformed_arrays() {
+    assert_eq!(parse_array("[1, true,]"), None); // trailing comma
+    assert_eq!(parse_array("[1 true]"), None); // missing comma
+    assert_eq!(parse_array("[1, "), None); // unterminated
+    assert_eq!(parse_array("not an array"), None);
+}


### PR DESCRIPTION
… types

- Added `parse_array` to handle JSON arrays of null, bool, number, and string values.
- Supports whitespace, comma-separated elements, and proper bracket handling.
- Rejects malformed arrays: missing commas, trailing commas, or unterminated structures.
- Improved with rustdoc examples and Clippy-compliant prefix handling.
- Includes unit tests for valid and invalid array formats.