### PR TITLE
feat: implement object parser with validation for keys and syntax rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ pub mod model;
 pub mod parser;
 
 pub use model::{JsonParseError, JsonValue};
-pub use parser::{parse_array, parse_bool, parse_null, parse_number, parse_string};
+pub use parser::{parse_array, parse_bool, parse_null, parse_number, parse_object, parse_string};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,10 +2,12 @@ pub mod array;
 pub mod bool;
 pub mod null;
 pub mod number;
+pub mod object;
 pub mod string;
 
 pub use array::parse_array;
 pub use bool::parse_bool;
 pub use null::parse_null;
 pub use number::parse_number;
+pub use object::parse_object;
 pub use string::parse_string;

--- a/src/parser/object.rs
+++ b/src/parser/object.rs
@@ -1,0 +1,84 @@
+use crate::model::JsonValue;
+use crate::parser::{parse_array, parse_bool, parse_null, parse_number, parse_string};
+
+use std::collections::HashMap;
+
+/// Attempts to parse a JSON object with string keys and simple values.
+///
+/// # Arguments
+///
+/// * `input` - A string slice expected to start with `'{'`.
+///
+/// # Returns
+///
+/// `Some((JsonValue::Object(map), remaining_input))` if successful, otherwise `None`.
+///
+/// # Examples
+///
+/// ```
+/// use synson::{parse_object, JsonValue};
+/// use std::collections::HashMap;
+///
+/// let mut expected = HashMap::new();
+/// expected.insert("a".to_string(), JsonValue::Number(1.0));
+///
+/// assert_eq!(
+///     parse_object("{\"a\": 1}"),
+///     Some((JsonValue::Object(expected), ""))
+/// );
+/// ```
+pub fn parse_object(input: &str) -> Option<(JsonValue, &str)> {
+    let mut input = input.trim_start();
+
+    if !input.starts_with('{') {
+        return None;
+    }
+    input = &input[1..];
+
+    let mut map = HashMap::new();
+
+    loop {
+        input = input.trim_start();
+
+        if let Some(rest) = input.strip_prefix('}') {
+            return Some((JsonValue::Object(map), rest));
+        }
+
+        // Parse key
+        let (JsonValue::String(key), rest) = parse_string(input)? else {
+            return None;
+        };
+
+        input = rest.trim_start();
+
+        // Expect colon
+        input = input.strip_prefix(':')?.trim_start();
+
+        // Parse value
+        let (value, rest) = parse_value(input)?;
+        map.insert(key, value);
+        input = rest.trim_start();
+
+        if let Some(rest) = input.strip_prefix(',') {
+            input = rest;
+
+            if input.trim_start().starts_with('}') {
+                return None;
+            }
+
+            continue;
+        } else if let Some(rest) = input.strip_prefix('}') {
+            return Some((JsonValue::Object(map), rest));
+        } else {
+            return None;
+        }
+    }
+}
+
+fn parse_value(input: &str) -> Option<(JsonValue, &str)> {
+    parse_null(input)
+        .or_else(|| parse_bool(input))
+        .or_else(|| parse_number(input))
+        .or_else(|| parse_string(input))
+        .or_else(|| parse_array(input))
+}

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+use synson::{parse_object, JsonValue};
+
+#[test]
+fn should_parse_simple_objects() {
+    let mut expected = HashMap::new();
+    expected.insert("a".to_string(), JsonValue::Number(1.0));
+    expected.insert("b".to_string(), JsonValue::Bool(true));
+    expected.insert("c".to_string(), JsonValue::String("ok".to_string()));
+
+    assert_eq!(
+        parse_object("{\"a\": 1, \"b\": true, \"c\": \"ok\"}"),
+        Some((JsonValue::Object(expected), ""))
+    );
+
+    assert_eq!(
+        parse_object("{ }"),
+        Some((JsonValue::Object(HashMap::new()), ""))
+    );
+}
+
+#[test]
+fn should_reject_invalid_objects() {
+    assert_eq!(parse_object("{a: 1}"), None); // key not quoted
+    assert_eq!(parse_object("{\"a\" 1}"), None); // missing colon
+    assert_eq!(parse_object("{\"a\": 1,}"), None); // trailing comma
+    assert_eq!(parse_object("{\"a\": 1 \"b\": 2}"), None); // missing comma
+    assert_eq!(parse_object("not an object"), None);
+}


### PR DESCRIPTION
- Added `parse_object` to handle JSON objects with string keys and simple values.
- Enforces proper use of quotes, colon, and comma separators.
- Rejects malformed objects: unquoted keys, trailing commas, missing colons.
- Includes rustdoc examples and full test coverage.