### PR TITLE
feat: add entry point parse_json with full validation and error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,6 @@ pub mod model;
 pub mod parser;
 
 pub use model::{JsonParseError, JsonValue};
-pub use parser::{parse_array, parse_bool, parse_null, parse_number, parse_object, parse_string};
+pub use parser::{
+    parse_array, parse_bool, parse_json, parse_null, parse_number, parse_object, parse_string,
+};

--- a/src/parser/json.rs
+++ b/src/parser/json.rs
@@ -1,0 +1,52 @@
+use crate::model::{JsonParseError, JsonValue};
+use crate::parser::{
+    parse_array, parse_bool, parse_null, parse_number, parse_object, parse_string,
+};
+
+/// Entry point for parsing a JSON value from input.
+///
+/// # Arguments
+///
+/// * `input` - A full JSON string.
+///
+/// # Returns
+///
+/// `Ok(JsonValue)` if successfully parsed and all input consumed,
+/// otherwise `Err(JsonParseError)`.
+///
+/// # Examples
+///
+/// ```
+/// use synson::{parse_json, JsonValue};
+///
+/// assert_eq!(
+///     parse_json(" 42 "),
+///     Ok(JsonValue::Number(42.0))
+/// );
+///
+/// assert_eq!(
+///     parse_json("true"),
+///     Ok(JsonValue::Bool(true))
+/// );
+/// ```
+pub fn parse_json(input: &str) -> Result<JsonValue, JsonParseError> {
+    let input = input.trim_start();
+
+    let (value, rest) = parse_null(input)
+        .or_else(|| parse_bool(input))
+        .or_else(|| parse_number(input))
+        .or_else(|| parse_string(input))
+        .or_else(|| parse_array(input))
+        .or_else(|| parse_object(input))
+        .ok_or_else(|| JsonParseError::new("Unrecognized JSON value", 0))?;
+
+    if !rest.trim_start().is_empty() {
+        let offset = input.len() - rest.trim_start().len();
+        return Err(JsonParseError::new(
+            "Trailing characters after JSON value",
+            offset,
+        ));
+    }
+
+    Ok(value)
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,6 @@
 pub mod array;
 pub mod bool;
+pub mod json;
 pub mod null;
 pub mod number;
 pub mod object;
@@ -7,6 +8,7 @@ pub mod string;
 
 pub use array::parse_array;
 pub use bool::parse_bool;
+pub use json::parse_json;
 pub use null::parse_null;
 pub use number::parse_number;
 pub use object::parse_object;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,0 +1,27 @@
+use synson::{parse_json, JsonValue};
+
+#[test]
+fn should_parse_valid_json_values() {
+    assert_eq!(parse_json("null"), Ok(JsonValue::Null));
+    assert_eq!(parse_json("true "), Ok(JsonValue::Bool(true)));
+    assert_eq!(
+        parse_json("\"ok\""),
+        Ok(JsonValue::String("ok".to_string()))
+    );
+    assert_eq!(parse_json("42"), Ok(JsonValue::Number(42.0)));
+    assert_eq!(
+        parse_json("[1, false]"),
+        Ok(JsonValue::Array(vec![
+            JsonValue::Number(1.0),
+            JsonValue::Bool(false)
+        ]))
+    );
+}
+
+#[test]
+fn should_reject_invalid_json_values() {
+    assert!(parse_json("nul").is_err());
+    assert!(parse_json("truefalse").is_err());
+    assert!(parse_json("42 garbage").is_err());
+    assert!(parse_json("}").is_err());
+}


### PR DESCRIPTION
- Implemented `parse_json` as a unified entry point for JSON parsing.
- Delegates to all specific parsers and checks full input consumption.
- Returns structured JsonParseError if parsing fails or input remains.
- Includes examples and unit tests for valid and invalid inputs.