### PR TITLE
refactor: centralize parse_value and add integration tests for nested…

### DIFF
--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -1,5 +1,6 @@
 use crate::model::JsonValue;
-use crate::parser::{parse_bool, parse_null, parse_number, parse_string};
+
+use super::parse_value;
 
 /// Attempts to parse a JSON array of simple values (null, bool, number, string).
 ///
@@ -68,11 +69,4 @@ pub fn parse_array(input: &str) -> Option<(JsonValue, &str)> {
             return None;
         }
     }
-}
-
-fn parse_value(input: &str) -> Option<(JsonValue, &str)> {
-    parse_null(input)
-        .or_else(|| parse_bool(input))
-        .or_else(|| parse_number(input))
-        .or_else(|| parse_string(input))
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,6 +5,7 @@ pub mod null;
 pub mod number;
 pub mod object;
 pub mod string;
+pub mod value;
 
 pub use array::parse_array;
 pub use bool::parse_bool;
@@ -13,3 +14,4 @@ pub use null::parse_null;
 pub use number::parse_number;
 pub use object::parse_object;
 pub use string::parse_string;
+pub use value::parse_value;

--- a/src/parser/object.rs
+++ b/src/parser/object.rs
@@ -1,7 +1,9 @@
 use crate::model::JsonValue;
-use crate::parser::{parse_array, parse_bool, parse_null, parse_number, parse_string};
+use crate::parser::parse_string;
 
 use std::collections::HashMap;
+
+use super::parse_value;
 
 /// Attempts to parse a JSON object with string keys and simple values.
 ///
@@ -73,12 +75,4 @@ pub fn parse_object(input: &str) -> Option<(JsonValue, &str)> {
             return None;
         }
     }
-}
-
-fn parse_value(input: &str) -> Option<(JsonValue, &str)> {
-    parse_null(input)
-        .or_else(|| parse_bool(input))
-        .or_else(|| parse_number(input))
-        .or_else(|| parse_string(input))
-        .or_else(|| parse_array(input))
 }

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -1,0 +1,12 @@
+use super::{parse_array, parse_bool, parse_null, parse_number, parse_object, parse_string};
+use crate::model::JsonValue;
+
+/// Attempts to parse any valid JSON value.
+pub fn parse_value(input: &str) -> Option<(JsonValue, &str)> {
+    parse_null(input)
+        .or_else(|| parse_bool(input))
+        .or_else(|| parse_number(input))
+        .or_else(|| parse_string(input))
+        .or_else(|| parse_array(input))
+        .or_else(|| parse_object(input))
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -19,8 +19,8 @@ fn should_parse_simple_arrays() {
 
 #[test]
 fn should_reject_malformed_arrays() {
-    assert_eq!(parse_array("[1, true,]"), None); // trailing comma
-    assert_eq!(parse_array("[1 true]"), None); // missing comma
-    assert_eq!(parse_array("[1, "), None); // unterminated
+    assert_eq!(parse_array("[1, true,]"), None);
+    assert_eq!(parse_array("[1 true]"), None);
+    assert_eq!(parse_array("[1, "), None);
     assert_eq!(parse_array("not an array"), None);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+use synson::{parse_json, JsonValue};
+
+fn build_expected() -> JsonValue {
+    let mut map = HashMap::new();
+    map.insert(
+        "key".to_string(),
+        JsonValue::Array(vec![
+            JsonValue::Null,
+            JsonValue::String("ok".to_string()),
+            JsonValue::Bool(false),
+        ]),
+    );
+    JsonValue::Object(map)
+}
+
+#[test]
+fn should_parse_full_valid_jsons() {
+    assert_eq!(
+        parse_json("{\"key\": [null, \"ok\", false]}"),
+        Ok(build_expected())
+    );
+
+    assert_eq!(
+        parse_json(" { \"key\" : [ null , \"ok\" , false ] } "),
+        Ok(build_expected())
+    );
+
+    assert_eq!(
+        parse_json("{\"a\": []}"),
+        Ok(JsonValue::Object({
+            let mut map = HashMap::new();
+            map.insert("a".to_string(), JsonValue::Array(vec![]));
+            map
+        }))
+    );
+
+    assert_eq!(
+        parse_json("{\"a\": {}}"),
+        Ok(JsonValue::Object({
+            let mut map = HashMap::new();
+            map.insert("a".to_string(), JsonValue::Object(HashMap::new()));
+            map
+        }))
+    );
+}
+
+#[test]
+fn should_fail_on_invalid_full_jsons() {
+    assert!(parse_json("{\"key\" \"missing colon\"}").is_err());
+    assert!(parse_json("[1, 2,]").is_err());
+    assert!(parse_json("{\"key\": [true,]").is_err());
+    assert!(parse_json("{\"key\": 123").is_err());
+    assert!(parse_json("{\"a\": 1 \"b\": 2}").is_err());
+    assert!(parse_json("{\"a\": true, \"b\"}").is_err());
+    assert!(parse_json("{\"a\" 1}").is_err());
+    assert!(parse_json("{\"a\": [1, null").is_err());
+}

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -21,9 +21,9 @@ fn should_parse_simple_objects() {
 
 #[test]
 fn should_reject_invalid_objects() {
-    assert_eq!(parse_object("{a: 1}"), None); // key not quoted
-    assert_eq!(parse_object("{\"a\" 1}"), None); // missing colon
-    assert_eq!(parse_object("{\"a\": 1,}"), None); // trailing comma
-    assert_eq!(parse_object("{\"a\": 1 \"b\": 2}"), None); // missing comma
+    assert_eq!(parse_object("{a: 1}"), None);
+    assert_eq!(parse_object("{\"a\" 1}"), None);
+    assert_eq!(parse_object("{\"a\": 1,}"), None);
+    assert_eq!(parse_object("{\"a\": 1 \"b\": 2}"), None);
     assert_eq!(parse_object("not an object"), None);
 }


### PR DESCRIPTION
… JSON

- Moved parse_value to parser/value.rs for reuse across object, array, and root parsing.
- Ensures consistent dispatch for all JSON types, including nested structures.
- Fixed object/array parsing to correctly handle embedded objects.
- Added full integration tests covering:
  - nested objects and arrays
  - heterogeneous structures
  - malformed edge cases (missing colon, trailing comma, etc.)