### PR TITLE
feat: support nested arrays and objects in JSON parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v0.2.0] - 2025-05-09
+
+### ✨ Added
+
+- Extended test suite for recursive parsing of nested arrays and objects.
+- New integration tests validating combinations of arrays and objects at arbitrary depth.
+- Improved documentation for `parse_object` to reflect support for nested structures.
+
+### ✅ JSON support
+
+- Confirmed support for deeply nested JSON structures via recursive `parse_value`.
+- Arrays and objects can now contain any valid JSON value, including nested arrays/objects.
+
+### 🧪 Test coverage
+
+- Added tests for cases like `[{"a": [true, false]}, 3]` and `{"user": {"id": 1, "tags": ["rust", "json"]}}`.
+- Added regression tests for deeply nested object trees (`{"a": {"b": {"c": {"d": null}}}}`).
+- Clarified function behavior through test-driven validation of recursive parsing.
+
 ## [v0.1.0] - 2025-05-08
 
 ### ✨ Added

--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -2,7 +2,7 @@ use crate::model::JsonValue;
 
 use super::parse_value;
 
-/// Attempts to parse a JSON array of simple values (null, bool, number, string).
+/// Attempts to parse a JSON array with potentially nested values.
 ///
 /// # Arguments
 ///
@@ -18,20 +18,19 @@ use super::parse_value;
 /// use synson::{parse_array, JsonValue};
 ///
 /// assert_eq!(
-///     parse_array("[1, true, \"ok\"]"),
+///     parse_array("[1, {\"a\": [true, false]}, 3]"),
 ///     Some((
 ///         JsonValue::Array(vec![
 ///             JsonValue::Number(1.0),
-///             JsonValue::Bool(true),
-///             JsonValue::String("ok".to_string())
+///             JsonValue::Object({
+///                 let mut map = std::collections::HashMap::new();
+///                 map.insert("a".to_string(), JsonValue::Array(vec![JsonValue::Bool(true), JsonValue::Bool(false)]));
+///                 map
+///             }),
+///             JsonValue::Number(3.0)
 ///         ]),
 ///         ""
 ///     ))
-/// );
-///
-/// assert_eq!(
-///     parse_array("[ ]"),
-///     Some((JsonValue::Array(vec![]), ""))
 /// );
 /// ```
 pub fn parse_array(input: &str) -> Option<(JsonValue, &str)> {

--- a/src/parser/object.rs
+++ b/src/parser/object.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use super::parse_value;
 
-/// Attempts to parse a JSON object with string keys and simple values.
+/// Attempts to parse a JSON object with potentially nested values.
 ///
 /// # Arguments
 ///
@@ -22,10 +22,18 @@ use super::parse_value;
 /// use std::collections::HashMap;
 ///
 /// let mut expected = HashMap::new();
-/// expected.insert("a".to_string(), JsonValue::Number(1.0));
+/// expected.insert("user".to_string(), JsonValue::Object({
+///     let mut inner = HashMap::new();
+///     inner.insert("id".to_string(), JsonValue::Number(1.0));
+///     inner.insert("tags".to_string(), JsonValue::Array(vec![
+///         JsonValue::String("rust".to_string()),
+///         JsonValue::String("json".to_string()),
+///     ]));
+///     inner
+/// }));
 ///
 /// assert_eq!(
-///     parse_object("{\"a\": 1}"),
+///     parse_object("{\"user\": {\"id\": 1, \"tags\": [\"rust\", \"json\"]}}"),
 ///     Some((JsonValue::Object(expected), ""))
 /// );
 /// ```
@@ -46,17 +54,14 @@ pub fn parse_object(input: &str) -> Option<(JsonValue, &str)> {
             return Some((JsonValue::Object(map), rest));
         }
 
-        // Parse key
         let (JsonValue::String(key), rest) = parse_string(input)? else {
             return None;
         };
 
         input = rest.trim_start();
 
-        // Expect colon
         input = input.strip_prefix(':')?.trim_start();
 
-        // Parse value
         let (value, rest) = parse_value(input)?;
         map.insert(key, value);
         input = rest.trim_start();

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -24,3 +24,53 @@ fn should_reject_malformed_arrays() {
     assert_eq!(parse_array("[1, "), None);
     assert_eq!(parse_array("not an array"), None);
 }
+
+#[test]
+fn should_parse_nested_arrays_and_objects() {
+    use std::collections::HashMap;
+
+    let result = parse_array(r#"[1, {"a": [true, false]}, 3]"#);
+    assert_eq!(
+        result,
+        Some((
+            JsonValue::Array(vec![
+                JsonValue::Number(1.0),
+                JsonValue::Object({
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "a".to_string(),
+                        JsonValue::Array(vec![JsonValue::Bool(true), JsonValue::Bool(false)]),
+                    );
+                    m
+                }),
+                JsonValue::Number(3.0),
+            ]),
+            ""
+        ))
+    );
+
+    let result = parse_array(r#"[{"x": 1}, {"x": {"y": [2, 3]}}]"#);
+    assert_eq!(
+        result,
+        Some((
+            JsonValue::Array(vec![
+                JsonValue::Object({
+                    let mut m = HashMap::new();
+                    m.insert("x".to_string(), JsonValue::Number(1.0));
+                    m
+                }),
+                JsonValue::Object({
+                    let mut inner = HashMap::new();
+                    inner.insert(
+                        "y".to_string(),
+                        JsonValue::Array(vec![JsonValue::Number(2.0), JsonValue::Number(3.0)]),
+                    );
+                    let mut m = HashMap::new();
+                    m.insert("x".to_string(), JsonValue::Object(inner));
+                    m
+                }),
+            ]),
+            ""
+        ))
+    );
+}

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -27,3 +27,44 @@ fn should_reject_invalid_objects() {
     assert_eq!(parse_object("{\"a\": 1 \"b\": 2}"), None);
     assert_eq!(parse_object("not an object"), None);
 }
+
+#[test]
+fn should_parse_nested_objects_and_arrays() {
+    let mut inner = HashMap::new();
+    inner.insert("id".to_string(), JsonValue::Number(1.0));
+    inner.insert(
+        "tags".to_string(),
+        JsonValue::Array(vec![
+            JsonValue::String("rust".to_string()),
+            JsonValue::String("json".to_string()),
+        ]),
+    );
+
+    let mut expected = HashMap::new();
+    expected.insert("user".to_string(), JsonValue::Object(inner));
+
+    assert_eq!(
+        parse_object(r#"{"user": {"id": 1, "tags": ["rust", "json"]}}"#),
+        Some((JsonValue::Object(expected), ""))
+    );
+}
+
+#[test]
+fn should_parse_deeply_nested_objects() {
+    let mut d = HashMap::new();
+    d.insert("d".to_string(), JsonValue::Null);
+
+    let mut c = HashMap::new();
+    c.insert("c".to_string(), JsonValue::Object(d));
+
+    let mut b = HashMap::new();
+    b.insert("b".to_string(), JsonValue::Object(c));
+
+    let mut a = HashMap::new();
+    a.insert("a".to_string(), JsonValue::Object(b));
+
+    assert_eq!(
+        parse_object(r#"{"a": {"b": {"c": {"d": null}}}}"#),
+        Some((JsonValue::Object(a), ""))
+    );
+}


### PR DESCRIPTION
- Extended test coverage to validate recursive parsing of arrays and objects
- parse_array and parse_object already supported nesting via parse_value
- Added tests for nested arrays and deeply nested objects
- Updated parse_object doc-comment to reflect support for nested values