### PR TITLE
feat: ensure trailing characters are rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v0.2.0] - 2025-05-11
+
 ### ✨ Added
 
 - Extended test suite for recursive parsing of nested arrays and objects.
@@ -23,6 +25,10 @@
     - Invalid number exponents and leading zeros in numbers.
 - Enhanced error logging to include position information (line, column, index) for better debugging.
 - Custom error handling for malformed JSON objects, arrays, and strings.
+- Trailing characters rejection: The JSON parser now rejects any remaining characters after successfully parsing a JSON value. If there are extra characters, the parser will return a detailed error message indicating the invalid content.
+  - Example errors:
+    - `"truex"`: Invalid because of trailing `x` after the valid `true`.
+    - `"{...} extra"`: Invalid because of the `extra` characters after a valid object.
 
 ### ✅ JSON support
 
@@ -42,6 +48,8 @@
   - Trailing commas in arrays.
   - Unterminated strings.
   - Invalid characters in booleans (`trueX`, `falseY`).
+- Now ensures that after parsing a valid JSON value (null, boolean, number, string, array, or object), no extra characters are left in the input string.
+- The parser will raise an error if there are characters that aren't part of the JSON value, improving strict compliance with JSON formatting.
 
 ### 🧪 Test coverage
 
@@ -59,6 +67,8 @@
     - Missing colons in objects (`{"key" "value"}`).
     - Invalid escape sequences in strings.
 - Fixed test cases for malformed JSON to ensure accurate error handling.
+- Added tests to validate that any extra characters in the input, after a valid JSON value, trigger an error.
+- Regression tests for various cases like `"truex"` and `"{...} extra"` ensuring proper error reporting for trailing characters.
 
 ## [v0.1.0] - 2025-05-08
 

--- a/src/parser/json.rs
+++ b/src/parser/json.rs
@@ -33,20 +33,13 @@ use crate::parser::parse_value;
 /// ```
 pub fn parse_json(input: &str) -> Result<JsonValue, JsonParseError> {
     let trimmed_input = input.trim_start();
-    println!("parse_json input: '{}'", input); // Log de l'input initial
 
     let (value, rest) = parse_value(trimmed_input)?;
 
     let rest_trimmed = rest.trim_start();
-    println!("parse_json value: {:?}", value); // Log de la valeur analysée
-    println!("parse_json rest: '{}'", rest); // Log de la partie restante
 
     if !rest_trimmed.is_empty() {
-        let offset = trimmed_input.len() - rest_trimmed.len();
-        println!(
-            "parse_json error: Trailing characters found at offset {}",
-            offset
-        );
+        let offset = input.len() - rest_trimmed.len();
         return Err(JsonParseError::new(
             "Trailing characters after JSON value",
             offset,

--- a/src/parser/object.rs
+++ b/src/parser/object.rs
@@ -49,8 +49,6 @@ pub fn parse_object(input: &str) -> Result<(JsonValue, &str), JsonParseError> {
     let original_input = input;
     let mut input = input.trim_start(); // mutable, pas "let input = ..."
 
-    println!("parse_object input: '{}'", input);
-
     if !input.starts_with('{') {
         return Err(JsonParseError::new(
             "Expected '{' to start object",
@@ -59,12 +57,11 @@ pub fn parse_object(input: &str) -> Result<(JsonValue, &str), JsonParseError> {
         ));
     }
 
-    input = &input[1..]; // skip '{'
+    input = &input[1..];
     let mut map = HashMap::new();
 
     loop {
         input = input.trim_start();
-        println!("parse_object loop input: '{}'", input);
 
         if let Some(rest) = input.strip_prefix('}') {
             return Ok((JsonValue::Object(map), rest));
@@ -76,7 +73,6 @@ pub fn parse_object(input: &str) -> Result<(JsonValue, &str), JsonParseError> {
         let JsonValue::String(key) = key_value else {
             return Err(JsonParseError::new("Object keys must be strings", 0, input));
         };
-        println!("parse_object key: {:?}", key);
 
         input = rest.trim_start();
 
@@ -89,7 +85,7 @@ pub fn parse_object(input: &str) -> Result<(JsonValue, &str), JsonParseError> {
             ));
         }
 
-        input = &input[1..]; // skip ':'
+        input = &input[1..];
         input = input.trim_start();
 
         let (value, rest) = parse_value(input)?;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -25,3 +25,21 @@ fn should_reject_invalid_json_values() {
     assert!(parse_json("42 garbage").is_err());
     assert!(parse_json("}").is_err());
 }
+
+#[test]
+fn should_report_trailing_characters_error() {
+    let err = parse_json("true false").unwrap_err();
+    assert_eq!(err.message, "Trailing characters after JSON value");
+    assert_eq!(err.index, 5);
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 6);
+}
+
+#[test]
+fn should_report_trailing_characters_after_object() {
+    let err = parse_json("{\"key\": true} extra").unwrap_err();
+    assert_eq!(err.message, "Trailing characters after JSON value");
+    assert_eq!(err.index, 14);
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 15);
+}


### PR DESCRIPTION
- Implemented a check to reject trailing characters after a valid JSON value.
- If characters follow the valid JSON, an error is returned with the appropriate offset.
- Updated tests to validate trailing characters after JSON objects and primitives.
- Remove println and comments